### PR TITLE
Alterations to documentation in downscaling examples

### DIFF
--- a/examples/3_static_downscaling/downscaling_example01.py
+++ b/examples/3_static_downscaling/downscaling_example01.py
@@ -2,6 +2,7 @@
 import os
 import sys
 # sys.path.append(r'/home/tacuevas/github/Kalpana/kalpana')
+## this is not necessary if the module is in the same folder
 from downscaling import meshRepLen2raster
 
 '''
@@ -14,9 +15,9 @@ fort14 = r'../adds/inputs_examples/fort.14' ## path of the fort.14 file
 epsgIn = 4326 ## CRS for lat/lon
 epsgOut = 6346 ## CRS of downscaling DEM
 pathOut = r'/home/tomas/Downloads/NC9_NCConED_25m.shp' ## full path of the output shapefile 
-grassVer = 8.2
+grassVer = 8.2 ## version of grass 8.2 and 8.3 works
 pathRasFiles = r'../adds/inputs_examples'
-rasterFiles = 'North_Carolina_CoNED_Topobathy_DEM_25m_version_20.tif'
+rasterFiles = 'NC_CoNED_subset_100m.tif'
 ## in this case we will use the same downscaling raster bounding box as the subdomain. 
 subDomain=os.path.join(pathRasFiles, rasterFiles)
 nameGrassLocation=None

--- a/examples/3_static_downscaling/downscaling_example02.py
+++ b/examples/3_static_downscaling/downscaling_example02.py
@@ -1,6 +1,7 @@
 import os
 import sys
 # sys.path.append(r'/home/tacuevas/github/Kalpana/kalpana')
+## this is not necessary if the module is in the same folder
 from downscaling import runStatic
 '''
 Example for doing the static downscaling using an existing grass location, and importing
@@ -26,7 +27,7 @@ grassVer = 8.2
 pathRasFiles = r'../adds/inputs_examples'
 ## rasters filenames, can be a list if more than one. 
 ## 'all' for importing ALL THE FILES in pathRasFiles 
-rasterFiles = 'North_Carolina_CoNED_Topobathy_DEM_25m_version_20.tif'
+rasterFiles = 'NC_CoNED_subset_100m.tif'
 ## full path of the raster with the mesh element size
 meshFile = r'/home/tomas/Downloads/NC9_NCConED_25m.tif'
 ## crs of adcirc output (default value)

--- a/examples/4_head_loss_downscaling/downscaling_example04.py
+++ b/examples/4_head_loss_downscaling/downscaling_example04.py
@@ -4,7 +4,7 @@ from downscalingHeadLoss import preCompCostSurface
 from loguru import logger
 
 # %%
-## grass version
+## version of grass 8.2 and 8.3 works
 grassVer = 8.2
 
 ## boolean flag for creating a GRASS GIS location


### PR DESCRIPTION
downscaling_example 01: I noted why the sys.path.append line can be ignored, specified which grass versions work with the example, and I changed the raster file to match the one in the GitHub repository.

downscaling_example 02: I noted why the sys.path.append line can be ignored and I changed the raster file to match the one in the GitHub repository.

downscaling_example 04: I specified which grass versions work with the example (8.2 & 8.3)
